### PR TITLE
build:自動でstylesheetのpassをgh-pagesのpassに合致するように./を消すようにした

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Build Css Test</title>
-    <link rel="stylesheet" crossorigin href="./assets/index-XW9yWM-1.css">
+    <link rel="stylesheet" crossorigin href="assets//index-S98byvUy.css">
   </head>
   <body>
     <p>styles/css deploy</p>

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,5 +1,5 @@
 body {
-  background-color: red;
+  background-color: yellow;
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 0;
@@ -8,7 +8,7 @@ body {
 p {
   margin: 0;
   padding: 0;
-  color: white;
+  color: blue;
 }
 
 img {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,6 @@
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
 export default {
   base: "",
   assetsInclude: [
@@ -14,4 +17,18 @@ export default {
     outDir: "dist",
     assetsDir: "assets",
   },
+  plugins: [
+    {
+      name: "remove-leading-dot",
+      apply: "build",
+      writeBundle() {
+        const distDir = "./dist";
+        const htmlFile = join(distDir, "index.html");
+        let content = readFileSync(htmlFile, "utf-8");
+        content = content.replace(/="\.\/assets/g, '="assets/');
+        // content = content.replace(/="\/assets/g, '="assets');
+        writeFileSync(htmlFile, content);
+      },
+    },
+  ],
 };


### PR DESCRIPTION
<details><summary>Details</summary>
<p>

 plugins: [
    {
      name: "remove-leading-dot",
      apply: "build",
      writeBundle() {
        const distDir = "./dist";
        const htmlFile = join(distDir, "index.html");
        let content = readFileSync(htmlFile, "utf-8");
        content = content.replace(/="\.\/assets/g, '="assets/');
        // content = content.replace(/="\/assets/g, '="assets');
        writeFileSync(htmlFile, content);
      },
    },
  ],

</p>
</details> 